### PR TITLE
Feature/validate s_hash

### DIFF
--- a/Entity/Grant/AuthorizationCodeGrant.php
+++ b/Entity/Grant/AuthorizationCodeGrant.php
@@ -10,16 +10,19 @@ class AuthorizationCodeGrant implements OidcGrantInterface {
 
   private string $code;
   private ?string $codeVerifier;
+  private ?string $state;
 
   /**
    * AuthorizationCodeGrant constructor.
    *
    * @param string      $code
    * @param string|null $codeVerifier
+   * @param string|null $state
    */
-  public function __construct(string $code, ?string $codeVerifier = null) {
+  public function __construct(string $code, ?string $codeVerifier = null, ?string $state = null) {
     $this->code = $code;
     $this->codeVerifier = $codeVerifier;
+    $this->state = $state;
   }
 
   /**
@@ -53,6 +56,23 @@ class AuthorizationCodeGrant implements OidcGrantInterface {
    */
   public function setCodeVerifier(?string $codeVerifier): self {
     $this->codeVerifier = $codeVerifier;
+    return $this;
+  }
+
+  /**
+   * @return string|null
+   */
+  public function getState(): ?string {
+    return $this->state;
+  }
+
+  /**
+   * @param string|null $state
+   *
+   * @return AuthorizationCodeGrant
+   */
+  public function setState(?string $state): self {
+    $this->state = $state;
     return $this;
   }
 

--- a/Factory/OidcTokenResponseFactory.php
+++ b/Factory/OidcTokenResponseFactory.php
@@ -126,6 +126,11 @@ class OidcTokenResponseFactory {
       throw new InvalidIdTokenException('c_hash did not match');
     }
 
+    $sHash = $idToken->getPayload()['s_hash'] ?? null;
+    if ($sHash && $grant instanceof AuthorizationCodeGrant && $grant->getState() && !OpenIdHashHelper::compare($grant->getState(), $sHash, $alg)) {
+      throw new InvalidIdTokenException('s_hash did not match');
+    }
+
     return $idToken;
   }
 


### PR DESCRIPTION
An addition the the oidc spec, [Financial-grade API Security Profile 1.0 - Part 2: Advanced](https://openid.net/specs/openid-financial-api-part-2-1_0.html), defines the `s_hash` in the id_token, this is similar to c_hash and at_hash, but for the state parameter.