### PR TITLE
FIX: make OauthAuthenticatorServiceFactory::create static.

### DIFF
--- a/Factory/OauthAuthenticatorServiceFactory.php
+++ b/Factory/OauthAuthenticatorServiceFactory.php
@@ -21,7 +21,7 @@ class OauthAuthenticatorServiceFactory {
    *
    * @return OauthAuthenticatorService
    */
-  public function create(OpenIdProviderServiceInterface $openIdProviderService, OauthJwkSetProviderServiceInterface $oauthJwkSetProvider) {
+  public static function create(OpenIdProviderServiceInterface $openIdProviderService, OauthJwkSetProviderServiceInterface $oauthJwkSetProvider): OauthAuthenticatorService {
     return new OauthAuthenticatorService(
       $openIdProviderService->getClientConfiguration()->getIssuer(),
       $oauthJwkSetProvider


### PR DESCRIPTION
Non-static method HalloVerden\Oidc\ClientBundle\Factory\OauthAuthenticatorServiceFactory::create() cannot be called statically (in PHP 8+)