### PR TITLE
Feature/make issuer and client id optional

### DIFF
--- a/Client/ClientConfiguration.php
+++ b/Client/ClientConfiguration.php
@@ -5,8 +5,8 @@ namespace HalloVerden\Oidc\ClientBundle\Client;
 
 
 class ClientConfiguration {
-  private string $issuer;
-  private string $clientId;
+  private ?string $issuer;
+  private ?string $clientId = null;
   private ?string $secret = null;
   private ?string $redirectUri = null;
   private ?string $openIdConfigurationEndpoint = null;
@@ -25,16 +25,16 @@ class ClientConfiguration {
   /**
    * ClientConfiguration constructor.
    *
-   * @param string $issuer
+   * @param string|null $issuer
    */
-  public function __construct(string $issuer) {
+  public function __construct(string $issuer = null) {
     $this->issuer = $issuer;
   }
 
   /**
-   * @return string
+   * @return string|null
    */
-  public function getIssuer(): string {
+  public function getIssuer(): ?string {
     return $this->issuer;
   }
 
@@ -49,9 +49,9 @@ class ClientConfiguration {
   }
 
   /**
-   * @return string
+   * @return string|null
    */
-  public function getClientId(): string {
+  public function getClientId(): ?string {
     return $this->clientId;
   }
 

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -22,7 +22,7 @@ class Configuration implements ConfigurationInterface {
         ->arrayNode('client_configurations')
           ->arrayPrototype()
             ->children()
-              ->scalarNode('issuer')->isRequired()->end()
+              ->scalarNode('issuer')->defaultNull()->end()
               ->scalarNode('client_id')->defaultNull()->end()
               ->scalarNode('client_secret')->defaultNull()->end()
               ->scalarNode('redirect_uri')->defaultNull()->end()

--- a/DependencyInjection/HalloVerdenOidcClientExtension.php
+++ b/DependencyInjection/HalloVerdenOidcClientExtension.php
@@ -82,7 +82,7 @@ class HalloVerdenOidcClientExtension extends Extension implements PrependExtensi
       ],
     );
 
-    if (isset($clientConfiguration['client_id'])) {
+    if (isset($clientConfigurationArray['client_id'])) {
       $clientConfiguration->addMethodCall('setClientId', [$clientConfigurationArray['client_id']]);
     }
 

--- a/DependencyInjection/HalloVerdenOidcClientExtension.php
+++ b/DependencyInjection/HalloVerdenOidcClientExtension.php
@@ -83,7 +83,7 @@ class HalloVerdenOidcClientExtension extends Extension implements PrependExtensi
     );
 
     if (isset($clientConfiguration['client_id'])) {
-      $clientConfiguration->addMethodCall('setClientId', $clientConfigurationArray['client_id']);
+      $clientConfiguration->addMethodCall('setClientId', [$clientConfigurationArray['client_id']]);
     }
 
     $clientConfiguration->addTag('hv.oidc.client_configuration', ['key' => $key]);

--- a/DependencyInjection/HalloVerdenOidcClientExtension.php
+++ b/DependencyInjection/HalloVerdenOidcClientExtension.php
@@ -65,7 +65,6 @@ class HalloVerdenOidcClientExtension extends Extension implements PrependExtensi
 
     $clientConfiguration->setMethodCalls(
       [
-        ['setClientId', [$clientConfigurationArray['client_id']]],
         ['setClientSecret', [$clientConfigurationArray['client_secret']]],
         ['setRedirectUri', [$clientConfigurationArray['redirect_uri']]],
         ['setOpenIdConfigurationEndpoint', [$clientConfigurationArray['openid_configuration_endpoint']]],
@@ -82,6 +81,10 @@ class HalloVerdenOidcClientExtension extends Extension implements PrependExtensi
         ['setJtwCustomClaims', [$clientConfigurationArray['jwt_custom_claims']]]
       ],
     );
+
+    if (isset($clientConfiguration['client_id'])) {
+      $clientConfiguration->addMethodCall('setClientId', $clientConfigurationArray['client_id']);
+    }
 
     $clientConfiguration->addTag('hv.oidc.client_configuration', ['key' => $key]);
 

--- a/Entity/Requests/Client/OidcAuthenticationRequest.php
+++ b/Entity/Requests/Client/OidcAuthenticationRequest.php
@@ -38,9 +38,14 @@ class OidcAuthenticationRequest implements OidcAuthenticationRequestInterface {
    * @return $this
    */
   public static function createFromConfigs(ClientConfiguration $clientConfiguration, ProviderConfiguration $providerConfiguration): self {
+    $clientId = $clientConfiguration->getClientId();
+    if (null === $clientId) {
+      throw new \RuntimeException('"client_id" is required to create authentication request.');
+    }
+
     $request = (new static())
       ->setScope($clientConfiguration->getScope())
-      ->setClientId($clientConfiguration->getClientId())
+      ->setClientId($clientId)
       ->setRedirectUri($clientConfiguration->getRedirectUri())
       ->setResponseType($clientConfiguration->getResponseType())
       ->setNonce(RandomHelper::generateRandomString($clientConfiguration->getNonceParameterLength(), true))


### PR DESCRIPTION
This makes the client_id and issuer optional in the configuration.

Useful if you need to contact oidc provider without having a client. like when fetching openid configuration + JWKS